### PR TITLE
Add link to LICENSE in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@ Project inspired by [concept](https://dribbble.com/shots/2242263--1-Pull-to-refr
 
 ## License
 
-RainyRefreshControl is released under the MIT license. See LICENSE for details.
+RainyRefreshControl is released under the MIT license. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
One can check if link works by going to https://github.com/Onix-Systems/RainyRefreshControl/tree/feature/add-link-to-license